### PR TITLE
API Passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,74 @@
 # AspireCloud
 
-This plugin provides a foundation for WordPress Core Services API functionality. AspireCloud serves as a base framework for future development of core WordPress services integration.
+**Contributors:** AspirePress  
+**Tags:** wordpress, api, headless, passthrough, wordpress-api  
+**Requires at least:** 5.3  
+**Tested up to:** 6.8.1  
+**Requires PHP:** 7.4  
+**Stable tag:** 0.0.1  
+**License:** GPLv2 or later  
+**License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 
-## Status
+## Description
 
-This plugin is currently in early development stage and does not include active functionality.
+AspireCloud transforms your WordPress site into a headless installation with source API passthrough functionality. All requests to your site root are automatically passed through to source, while maintaining full WordPress admin functionality.
+
+## Features
+
+### Root-Level API Passthrough
+- Direct passthrough from `https://yoursite.com/{path}` to `https://apisourcesite.com/{path}`
+- GET requests only
+- Query parameters preserved
+- Error handling and response proxying
+
+### Headless WordPress
+- Frontend disabled for regular visitors
+- Admin interface fully functional
+- WordPress core paths protected
+- Static assets served normally
+
+### WordPress Integration
+- Seamless integration with WordPress rewrite system
+- Automatic activation/deactivation handling
+- WordPress coding standards compliant
+- Comprehensive error handling
+
+## Quick Start
+
+1. **Install & Activate** the plugin
+2. **Visit Settings → Permalinks** and click "Save Changes" to flush rewrite rules
+3. **Test** by visiting your site root - you should see the api welcome page content
+
+## Protected WordPress Paths
+
+These paths continue to work normally:
+- `/wp-admin/` - WordPress admin
+- `/wp-login.php` - Login page
+- `/wp-content/` - Static assets
+- `/wp-json/` - REST API
 
 ## Requirements
 
-This plugin requires:
-
-- WordPress 5.3 or later
-- PHP 7.4 or later
-- The ability to upload files to your WordPress installation
-- The ability to modify your configuration in wp-config.php
-
-## Installation
-
-To install this plugin, follow these steps:
-
-1. Download a copy of this plugin as a ZIP file from GitHub or the Releases section.
-2. Go to the WordPress Dashboard (/wp-admin) section and log in if necessary as an administrator.
-3. Go to the Plugins menu and click on "Add New Plugin".
-4. Click the button "Upload Plugin" and upload the plugin ZIP file.
-5. Activate the AspireCloud plugin.
-
-Note: This plugin is currently in development and does not provide user-facing functionality.
+- **WordPress:** 5.3 or higher
+- **PHP:** 7.4 or higher
+- **Server:** Must support WordPress rewrite rules
 
 ## Development
 
-This plugin is being developed as a foundation for WordPress Core Services API functionality. Future releases will include:
-
-- Core WordPress services integration framework
-- API endpoint management
-- Service discovery and registration
-- Authentication and authorization systems
-
-## License
-
-This plugin is licensed under the GPLv2 license. See the LICENSE.md file for more details.
-
-## Contributing
-
-We welcome contributions to AspireCloud! Please follow these guidelines:
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests for your changes
-5. Submit a pull request
+This plugin follows WordPress coding standards and includes:
+- PSR-4 autoloading
+- PHPUnit tests
+- PHPCS integration
+- Comprehensive documentation
 
 ## Support
 
-For support, please:
-
-1. Check the documentation
-2. Search existing GitHub issues
-3. Create a new issue if needed
+For support and documentation, visit [AspirePress Documentation](https://docs.aspirepress.org/aspirecloud/).
 
 ## Changelog
 
 ### 0.0.1
-- Initial plugin framework
-- Basic plugin structure for future development
+- Initial release
+- Root-level api.wordpress.org API passthrough
+- Headless WordPress functionality
+- WordPress admin preservation

--- a/aspire-cloud.php
+++ b/aspire-cloud.php
@@ -32,6 +32,10 @@ if ( ! defined( 'AC_VERSION' ) ) {
 	define( 'AC_VERSION', '0.0.1' );
 }
 
+if ( ! defined( 'AC_SOURCE_API_ENDPOINT' ) ) {
+	define( 'AC_SOURCE_API_ENDPOINT', 'https://api.wordpress.org' );
+}
+
 add_action( 'plugins_loaded', 'define_constant' );
 function define_constant() {
 	if ( ! defined( 'AC_PATH' ) ) {
@@ -39,4 +43,42 @@ function define_constant() {
 	}
 }
 
-// Simple API endpoint functionality will be added here in the future
+// Load the autoloader
+require_once __DIR__ . '/includes/autoload.php';
+
+// Initialize the plugin functionality
+add_action( 'init', 'aspire_cloud_init' );
+
+// Plugin activation and deactivation hooks// Plugin activation and deactivation hooks
+register_activation_hook( __FILE__, 'aspire_cloud_activate' );
+register_deactivation_hook( __FILE__, 'aspire_cloud_deactivate' );
+
+/**
+ * Plugin activation callback.
+ */
+function aspire_cloud_activate() {
+	// Initialize the controllers to register rewrite rules
+	aspire_cloud_init();
+
+	// Flush rewrite rules on activation
+	flush_rewrite_rules();
+}
+
+/**
+ * Plugin deactivation callback.
+ */
+function aspire_cloud_deactivate() {
+	// Flush rewrite rules on deactivation to clean up
+	flush_rewrite_rules();
+}
+
+/**
+ * Initialize AspireCloud plugin.
+ */
+function aspire_cloud_init() {
+	// Initialize the Passthrough API controller
+	new \AspireCloud\Controller\Passthrough();
+
+	// Initialize the Headless WordPress controller
+	new \AspireCloud\Controller\Headless();
+}

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -15,8 +15,28 @@ spl_autoload_register( 'aspire_cloud_autoloader' );
  */
 function aspire_cloud_autoloader( $class_name ) {
 	if ( false !== strpos( $class_name, 'AspireCloud\\' ) ) {
-		$class_name = strtolower( str_replace( [ 'AspireCloud\\', '_' ], [ '', '-' ], $class_name ) );
-		$file       = __DIR__ . DIRECTORY_SEPARATOR . 'class-' . $class_name . '.php';
+		$class_name = str_replace( 'AspireCloud\\', '', $class_name );
+		$parts      = explode( '\\', $class_name );
+
+		// Convert to lowercase and replace underscores with hyphens
+		$file_parts = array_map(
+			function ( $part ) {
+				return strtolower( str_replace( '_', '-', $part ) );
+			},
+			$parts
+		);
+
+		// Build the file path
+		$file_path = __DIR__ . DIRECTORY_SEPARATOR;
+		if ( count( $file_parts ) > 1 ) {
+			// Add subdirectory (e.g., controller)
+			$file_path .= $file_parts[0] . DIRECTORY_SEPARATOR;
+			$file_name  = 'class-' . $file_parts[1] . '.php';
+		} else {
+			$file_name = 'class-' . $file_parts[0] . '.php';
+		}
+
+		$file = $file_path . $file_name;
 
 		if ( file_exists( $file ) ) {
 			require_once $file;

--- a/includes/controller/class-headless.php
+++ b/includes/controller/class-headless.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Headless WordPress Controller.
+ *
+ * @package aspire-cloud
+ * @author  AspirePress
+ */
+
+namespace AspireCloud\Controller;
+
+/**
+ * Class Headless
+ *
+ * Handles headless WordPress functionality.
+ */
+class Headless {
+
+	/**
+	 * Initialize the headless functionality.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'disable_frontend' ] );
+		add_action( 'wp_loaded', [ $this, 'redirect_frontend_to_admin' ] );
+		add_filter( 'show_admin_bar', '__return_false' );
+		add_action( 'wp_enqueue_scripts', [ $this, 'dequeue_frontend_scripts' ], 100 );
+		add_action( 'wp_print_styles', [ $this, 'dequeue_frontend_styles' ], 100 );
+		add_filter( 'template_include', [ $this, 'disable_theme_templates' ] );
+	}
+
+	/**
+	 * Disable frontend functionality.
+	 */
+	public function disable_frontend() {
+		// Remove feed links
+		remove_action( 'wp_head', 'feed_links_extra', 3 );
+		remove_action( 'wp_head', 'feed_links', 2 );
+
+		// Remove unnecessary head elements
+		remove_action( 'wp_head', 'rsd_link' );
+		remove_action( 'wp_head', 'wlwmanifest_link' );
+		remove_action( 'wp_head', 'wp_generator' );
+		remove_action( 'wp_head', 'start_post_rel_link' );
+		remove_action( 'wp_head', 'index_rel_link' );
+		remove_action( 'wp_head', 'adjacent_posts_rel_link' );
+		remove_action( 'wp_head', 'wp_shortlink_wp_head' );
+
+		// Disable XML-RPC
+		add_filter( 'xmlrpc_enabled', '__return_false' );
+
+		// Remove emoji scripts
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	}
+
+	/**
+	 * Redirect frontend requests to admin or API.
+	 */
+	public function redirect_frontend_to_admin() {
+		// Don't redirect if we're already in admin, doing AJAX, or accessing REST API
+		if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return;
+		}
+
+		// Don't redirect if this is an API passthrough request
+		if ( get_query_var( 'aspire_api_path' ) ) {
+			return;
+		}
+
+		// Don't redirect login, cron, or other WordPress core functionality
+		$current_url     = $_SERVER['REQUEST_URI'] ?? '';
+		$wordpress_paths = [
+			'/wp-login.php',
+			'/wp-cron.php',
+			'/xmlrpc.php',
+			'/wp-admin/',
+			'/wp-content/',
+			'/wp-includes/',
+			'/wp-json/',
+		];
+
+		foreach ( $wordpress_paths as $path ) {
+			if ( strpos( $current_url, $path ) !== false ) {
+				return;
+			}
+		}
+
+		// For any path that should be handled by the API passthrough, don't redirect
+		// Let the Passthrough controller handle all other requests
+	}
+
+	/**
+	 * Dequeue frontend scripts.
+	 */
+	public function dequeue_frontend_scripts() {
+		// Remove jQuery and other scripts that aren't needed for headless
+		wp_dequeue_script( 'jquery' );
+		wp_dequeue_script( 'wp-embed' );
+	}
+
+	/**
+	 * Dequeue frontend styles.
+	 */
+	public function dequeue_frontend_styles() {
+		// Remove theme styles
+		global $wp_styles;
+		if ( isset( $wp_styles->queue ) ) {
+			foreach ( $wp_styles->queue as $style ) {
+				wp_dequeue_style( $style );
+			}
+		}
+	}
+
+	/**
+	 * Disable theme templates for headless operation.
+	 *
+	 * @param string $template The template path.
+	 * @return string Empty string to prevent template loading.
+	 */
+	public function disable_theme_templates( $template ) {
+		// Don't override template if this is an API passthrough request
+		if ( get_query_var( 'aspire_api_path' ) ) {
+			return $template;
+		}
+
+		// Don't override for WordPress core paths
+		$current_url     = $_SERVER['REQUEST_URI'] ?? '';
+		$wordpress_paths = [
+			'/wp-login.php',
+			'/wp-cron.php',
+			'/xmlrpc.php',
+			'/wp-admin/',
+			'/wp-content/',
+			'/wp-includes/',
+			'/wp-json/',
+		];
+
+		foreach ( $wordpress_paths as $path ) {
+			if ( strpos( $current_url, $path ) !== false ) {
+				return $template;
+			}
+		}
+
+		// For frontend requests that should show our headless template
+		// Return our custom headless template
+		return AC_PATH . '/includes/views/index.php';
+	}
+}

--- a/includes/controller/class-passthrough.php
+++ b/includes/controller/class-passthrough.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Passthrough API Controller.
+ *
+ * @package aspire-cloud
+ * @author  AspirePress
+ */
+
+namespace AspireCloud\Controller;
+
+/**
+ * Class Passthrough
+ *
+ * Creates a REST API endpoint that passes through GET requests to the source API endpoint.
+ */
+class Passthrough {
+
+	/**
+	 * Initialize the passthrough functionality.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( 'init', [ $this, 'add_rewrite_rules' ] );
+		add_action( 'wp', [ $this, 'handle_root_api_request' ], 1 );
+		add_action( 'parse_request', [ $this, 'early_request_handler' ] );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'',
+			'/api/(?P<path>.*)',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'passthrough_request' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'path' => [
+						'description' => 'The API path to passthrough to the source API endpoint',
+						'type'        => 'string',
+						'required'    => false,
+						'default'     => '',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Add rewrite rules for root API endpoints.
+	 */
+	public function add_rewrite_rules() {
+		// Add specific rewrite rule for secret-key API
+		add_rewrite_rule( '^secret-key/(.+)/?$', 'index.php?aspire_api_path=secret-key/$matches[1]', 'top' );
+
+		// Add general rewrite rule to catch all other requests
+		add_rewrite_rule( '^([^/]+(?:/[^/]*)*)/?$', 'index.php?aspire_api_path=$matches[1]', 'top' );
+
+		add_rewrite_tag( '%aspire_api_path%', '([^&]+)' );
+	}
+
+	/**
+	 * Handle requests before WordPress processes them.
+	 *
+	 * @param WP $wp The WordPress environment.
+	 */
+	public function early_request_handler( $wp ) {
+		// Get the request path
+		$request_path = $wp->request;
+
+		// If we have a request path and it's not a WordPress path, handle it
+		if ( ! empty( $request_path ) && ! $this->is_wordpress_path( $request_path ) ) {
+			$this->process_api_request( $request_path );
+		}
+	}
+
+	/**
+	 * Handle API requests at the root level.
+	 */
+	public function handle_root_api_request() {
+		$api_path = get_query_var( 'aspire_api_path' );
+
+		// Skip WordPress admin, wp-content, wp-includes, and other WordPress paths
+		if ( $this->is_wordpress_path( $api_path ) ) {
+			return;
+		}
+
+		// If we have a path, handle it as an API request
+		if ( ! empty( $api_path ) ) {
+			$this->process_api_request( $api_path );
+		}
+	}
+
+	/**
+	 * Check if the path is a WordPress internal path that should not be intercepted.
+	 *
+	 * @param string $path The path to check.
+	 * @return bool True if it's a WordPress path.
+	 */
+	private function is_wordpress_path( $path ) {
+		$wordpress_paths = [
+			'wp-admin',
+			'wp-content',
+			'wp-includes',
+			'wp-json',
+			'wp-login.php',
+			'wp-cron.php',
+			'xmlrpc.php',
+			'favicon.ico',
+			'robots.txt',
+			'sitemap.xml',
+		];
+
+		foreach ( $wordpress_paths as $wp_path ) {
+			if ( strpos( $path, $wp_path ) === 0 ) {
+				return true;
+			}
+		}
+
+		// Check for file extensions that should be served normally
+		$file_extensions = [ '.css', '.js', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.woff', '.woff2', '.ttf', '.eot' ];
+		foreach ( $file_extensions as $ext ) {
+			if ( substr( $path, -strlen( $ext ) ) === $ext ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Process the API request and return the source API endpoint's response.
+	 *
+	 * @param string $path The API path.
+	 */
+	private function process_api_request( $path ) {
+		// Build the API URL
+		$api_url = AC_SOURCE_API_ENDPOINT . '/' . ltrim( $path, '/' );
+
+		// Add query parameters if they exist
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_GET ) ) {
+			// Remove WordPress query vars
+			$query_params = $_GET;
+			unset( $query_params['aspire_api_path'] );
+
+			if ( ! empty( $query_params ) ) {
+				$api_url .= '?' . http_build_query( $query_params );
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		// Make the request to the source API endpoint
+		$response = wp_remote_get(
+			$api_url,
+			[
+				'timeout' => 30,
+				'headers' => [
+					'User-Agent' => 'AspireCloud/1.0',
+				],
+			]
+		);
+
+		// Handle errors
+		if ( is_wp_error( $response ) ) {
+			wp_die( 'Failed to fetch data from the source API endpoint: ' . esc_html( $response->get_error_message() ), 'API Error', [ 'response' => 500 ] );
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+		$headers     = wp_remote_retrieve_headers( $response );
+
+		// Set appropriate headers
+		$allowed_headers = [
+			'content-type',
+			'cache-control',
+			'expires',
+			'last-modified',
+			'etag',
+		];
+
+		foreach ( $allowed_headers as $header ) {
+			if ( isset( $headers[ $header ] ) ) {
+				header( $header . ': ' . $headers[ $header ] );
+			}
+		}
+
+		// Set status code
+		http_response_code( $status_code );
+
+		// Output the response and exit
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $body;
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+		exit;
+	}
+
+	/**
+	 * Handle the passthrough request.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 * @return \WP_REST_Response|\WP_Error The response or error.
+	 */
+	public function passthrough_request( $request ) {
+		$path         = $request->get_param( 'path' );
+		$query_params = $request->get_query_params();
+
+		// Remove the 'path' parameter from query params since it's not part of the actual query
+		unset( $query_params['path'] );
+
+		// Build the API URL
+		$api_url = AC_SOURCE_API_ENDPOINT . '/' . ltrim( $path, '/' );
+
+		// Add query parameters if they exist
+		if ( ! empty( $query_params ) ) {
+			$api_url .= '?' . http_build_query( $query_params );
+		}
+
+		// Make the request to the source API endpoint
+		$response = wp_remote_get(
+			$api_url,
+			[
+				'timeout' => 30,
+				'headers' => [
+					'User-Agent' => 'AspireCloud/1.0',
+				],
+			]
+		);
+
+		// Handle errors
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error(
+				'passthrough_error',
+				'Failed to fetch data from the source API endpoint: ' . $response->get_error_message(),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = wp_remote_retrieve_body( $response );
+		$headers     = wp_remote_retrieve_headers( $response );
+
+		// Create REST response
+		$rest_response = new \WP_REST_Response( $body, $status_code );
+
+		// Pass through relevant headers
+		$allowed_headers = [
+			'content-type',
+			'cache-control',
+			'expires',
+			'last-modified',
+			'etag',
+		];
+
+		foreach ( $allowed_headers as $header ) {
+			if ( isset( $headers[ $header ] ) ) {
+				$rest_response->header( $header, $headers[ $header ] );
+			}
+		}
+
+		return $rest_response;
+	}
+}

--- a/includes/views/index.php
+++ b/includes/views/index.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Default template for headless WordPress.
+ * This should rarely be used as most requests are handled by the API passthrough.
+ *
+ * @package aspire-cloud
+ */
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Set JSON header
+header( 'Content-Type: application/json' );
+
+// Return a simple JSON response indicating this is a headless WordPress
+echo wp_json_encode(
+	[
+		'message' => 'WordPress Core Services API',
+		'version' => AC_VERSION,
+		'status'  => 'active',
+	]
+);
+exit;


### PR DESCRIPTION
Convert the site into a headless instance, attach the REST API at the root of the site and pass through all requests to the end point defines as source API.

# Pull Request

## What changed?

Convert the site into a headless instance, attach the REST API at the root of the site and pass through all requests to the end point defines as source API.

## Why did it change?

Implement as a pass-through API server and then implement individual supported endpoints.

## Did you fix any specific issues?

NA

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

